### PR TITLE
Use correct Nunjucks filter name to strip title tags

### DIFF
--- a/_includes/blades/html.njk
+++ b/_includes/blades/html.njk
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover" />
     <link rel="icon" href="{{ site.favicon | d('/favicon.ico') }}" />
     <title>
-      {{- title | strip_html ~ ' | ' if title -}}
+      {{- title | striptags ~ ' | ' if title -}}
       {{- site.title -}}
     </title>
     <meta name="description" content="{{ description | d(site.description) }}" />


### PR DESCRIPTION
This PR is a fix for the following bug.

Using https://github.com/anydigital/build-awesome-starter and adding to index.md at the top:
```
---
title: My Site
---
```
cause the following error with `npm start`:

```
[11ty] Problem writing Eleventy templates:
[11ty] 1. Having trouble writing to "./_site/index.html" from "./site-1/index.md" (via EleventyTemplateError)
[11ty] 2. (./site-1/_includes/default.njk)
[11ty]   Error: filter not found: strip_html (via Template render error)
[11ty] 3. filter not found: strip_html
```