### PR TITLE
Add Twig variants of the html, links and sitemap blades

### DIFF
--- a/_includes/blades/html.twig
+++ b/_includes/blades/html.twig
@@ -1,0 +1,52 @@
+{# <!--section:code-->```twig #}
+<!doctype html>
+<html lang="{{ site.lang|default('en') }}">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover" />
+    <link rel="icon" href="{{ site.favicon|default('/favicon.svg') }}" />
+    {% if site.favicon_alt %}
+      <link rel="alternate icon" href="{{ site.favicon_alt }}" type="image/png" />
+    {% endif %}
+    <title>
+      {{- title ? title|striptags ~ ' | ' -}}
+      {{- site.title -}}
+    </title>
+    <meta name="description" content="{{ description|striptags }}" />
+
+    {%- for href in site.styles %}
+      <link rel="stylesheet" href="{{ href }}" />
+    {%- endfor %}
+    <style>
+      {{ site.inline_styles|default([])|join('\n')|raw }}
+    </style>
+
+    {%- for src in site.scripts %}
+      <script src="{{ src }}" defer></script>
+    {%- endfor %}
+    <script type="module">
+      {{ site.inline_scripts|default([])|join('\n')|raw }}
+    </script>
+
+    {{ content_for_header|default('')|raw }}
+  </head>
+
+  <body>
+    {% block body %}
+    {% endblock %}
+  </body>
+</html>
+{#```
+- `title ? …` renders the prefix only when a title is set, mirroring the Nunjucks `if title` guard.
+
+<!--section:docs-->
+Usage in Twig layout:
+
+```twig
+{% extends 'blades/html.twig' %}
+
+{% block body %}...{% endblock %}
+```
+
+Pass `site`, `title` and `description` via the render context.
+<!--section--> #}

--- a/_includes/blades/links.twig
+++ b/_includes/blades/links.twig
@@ -1,0 +1,18 @@
+{# <!--section:code-->```twig #}
+<ul>
+  {%- for link in links %}
+    <li>
+      <a href="{{ link.url }}" {% if link.url == current_url %}aria-current="page"{% endif %}>
+        {{- link.title -}}
+      </a>
+    </li>
+  {%- endfor %}
+</ul>
+{#```
+<!--section:docs-->
+Pass the links and the current URL explicitly so nothing else leaks into scope:
+
+```twig
+{% include 'blades/links.twig' with { links: menu, current_url: app.request.pathInfo } only %}
+```
+<!--section--> #}

--- a/_includes/blades/sitemap.xml.twig
+++ b/_includes/blades/sitemap.xml.twig
@@ -1,0 +1,23 @@
+{#- Based on https://github.com/11ty/eleventy-base-blog/blob/main/content/sitemap.xml.njk
+<!--section:code-->```twig -#}
+<?xml version="1.0" encoding="utf-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  {%- for page in collections.all %}
+    {% if page.data.permalink != false %}
+      <url>
+        <loc>{{ site.base }}{{ page.url }}</loc>
+        <lastmod>{{ page.date|date('c') }}</lastmod>
+      </url>
+    {% endif %}
+  {%- endfor %}
+</urlset>
+{#```
+<!--section:docs-->
+Render from a standalone route/template that outputs `application/xml`:
+
+```twig
+{% include 'blades/sitemap.xml.twig' %}
+```
+
+`date('c')` emits an ISO-8601 `lastmod`, which is what the sitemap spec expects.
+<!--section--> #}


### PR DESCRIPTION
Adds Twig versions of the existing blades, so the snippets are usable from Twig-based stacks (Symfony, Grav, Craft, Drupal) alongside the current Nunjucks and Liquid ones.

### New files
- `_includes/blades/html.twig`
- `_includes/blades/links.twig`
- `_includes/blades/sitemap.xml.twig`

### Notes
- Mirrors the `<!--section:code-->` / `<!--section:docs-->` markers and code-fence convention of the `.njk` / `.liquid` files, so they should slot straight into the docs site.
- `html.twig` uses block inheritance (`{% extends %}` + `{% block body %}`), matching the Nunjucks pattern.
- Filter mapping: `d()`/`default:` → `default()`, `strip_html`/`striptags` → `striptags`, `safe` → `raw`, `append:` → `~`.
- The Liquid `relative_url` filter has no native Twig equivalent, so style hrefs are emitted as-is (wrap with `|url`/`asset()` per framework if needed).
- `sitemap.xml.twig` uses `date('c')` for an ISO-8601 `lastmod`.

These are reference snippets only; they aren't part of the CSS build, so nothing in the existing pipeline is affected.